### PR TITLE
Fix error when mixing partially vectorized fluids

### DIFF
--- a/src/open_petro_elastic/config/fluids.py
+++ b/src/open_petro_elastic/config/fluids.py
@@ -64,9 +64,9 @@ class Fluids:
 
     @validator("constituents")
     def fractions_should_not_exceed_one(cls, v):
-        fractions = np.array([c.fraction for c in v if c.fraction is not None])
+        fraction_sum = sum([c.fraction for c in v if c.fraction is not None])
         epsilon = 1e-5
-        if np.any(sum(fractions) > 1.0 + epsilon):
+        if np.any(fraction_sum > 1.0 + epsilon):
             raise ValueError("Sum of constituent fractions should not exceed 1.0")
         return v
 

--- a/tests/test_fluid_mixing.py
+++ b/tests/test_fluid_mixing.py
@@ -1,9 +1,11 @@
+import numpy as np
 from generators import fluids, ratios, positives
 from hypothesis import assume, given
 from numpy.testing import assert_allclose
 from predicates import assert_similar_material
 
 from open_petro_elastic.material import brie_fluid_mixing, wood_fluid_mixing
+from open_petro_elastic.material.fluid import fluid_material
 
 
 @given(fluids(), fluids(), fluids(), ratios(), ratios())
@@ -86,3 +88,15 @@ def test_bries_two_liquids_two_gases(
     )
     assert min(g.bulk_modulus for g in gases) <= mix.bulk_modulus
     assert mix.bulk_modulus <= max(liq.bulk_modulus for liq in liquids)
+
+
+def test_woods_mixing_with_partial_vectorization():
+    fluid1 = fluid_material(bulk_modulus=np.ones(4) * 1e7, density=np.ones(4) * 1e4)
+    fluid2 = fluid_material(bulk_modulus=np.ones(4) * 1e8, density=np.ones(4) * 1e5)
+    fluid3 = fluid_material(bulk_modulus=np.ones(4) * 1e9, density=np.ones(4) * 1e6)
+    s0 = 0.1
+    s1 = np.array([0.5, 0.6, 0.7, 0.8])
+    s2 = 1.0 - s1 - s0
+    saturations = [s0, s1, s2]
+    mixed = wood_fluid_mixing([fluid1, fluid2, fluid3], saturations)
+    assert mixed.bulk_modulus.shape == (4,)


### PR DESCRIPTION
When using Wood's mixing model, saturations may be provided as arrays or scalars. However, a combination of the two will cause an error when constructing a Material. The error is related to how np.array handles a list of a combination of arrays and scalars, and a related deprecation warning is produced by Fluids.fractions_should_not_exceed_one. Using built-in 'sum' should solve this issue, instead of np.array followed by np.sum.