### PR TITLE
Alignment with original code from Norunn Skjei and implementation in RokDoc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ quantities
 pandas
 scipy
 sympy
+pydantic

--- a/src/open_petro_elastic/__main__.py
+++ b/src/open_petro_elastic/__main__.py
@@ -59,6 +59,12 @@ def calculate_results(inp):
             "mysat": saturated_rock.shear_modulus,
             "rsat": saturated_rock.density,
             "kmin_fls": dense_packing.bulk_modulus,
+            "mumin_fls": dense_packing.shear_modulus,
+            "kfl": mixed_fluid.bulk_modulus,
+            "rhofl": mixed_fluid.density,
+            "vp": saturated_rock.primary_velocity,
+            "vs": saturated_rock.secondary_velocity,
+            "depth": inp.data['Depth'],
         },
         index=index,
     )
@@ -200,7 +206,7 @@ def run_with_threshold(args):
         )
         return -5
     try:
-        results.to_csv(args.output_file)
+        results.to_csv(args.output_file, index=False, line_terminator='\n')
     except Exception as e:
         print(f"Encountered unexpected error while writing output: {e}")
         print_tb(e.__traceback__)

--- a/src/open_petro_elastic/config/minerals.py
+++ b/src/open_petro_elastic/config/minerals.py
@@ -5,7 +5,7 @@ from pydantic import conlist
 from pydantic.dataclasses import dataclass
 
 from open_petro_elastic.float_vectorize import float_vectorize
-from open_petro_elastic.material import Material, hashin_shtrikman_average, hashin_shtrikman_walpole
+from open_petro_elastic.material import Material, hashin_shtrikman_walpole
 
 from .constituent import Constituent, fix_one_fraction
 from .pydantic_config import PetroElasticConfig

--- a/src/open_petro_elastic/config/minerals.py
+++ b/src/open_petro_elastic/config/minerals.py
@@ -5,7 +5,7 @@ from pydantic import conlist
 from pydantic.dataclasses import dataclass
 
 from open_petro_elastic.float_vectorize import float_vectorize
-from open_petro_elastic.material import Material, hashin_shtrikman_average
+from open_petro_elastic.material import Material, hashin_shtrikman_average, hashin_shtrikman_walpole
 
 from .constituent import Constituent, fix_one_fraction
 from .pydantic_config import PetroElasticConfig
@@ -62,7 +62,7 @@ class Minerals:
         for next_mineral in self[1:]:
             sub_total = mixed_mineral.fraction + next_mineral.fraction
             fraction = part_of_total(mixed_mineral.fraction, sub_total)
-            new_mix = hashin_shtrikman_average(
+            new_mix = hashin_shtrikman_walpole(
                 mixed_mineral.material, next_mineral.material, fraction
             )
             mixed_mineral = Constituent(

--- a/src/open_petro_elastic/material/sandstone/patchy_cement.py
+++ b/src/open_petro_elastic/material/sandstone/patchy_cement.py
@@ -21,25 +21,26 @@ def patchy_cement(
     lower_bound_pressure,
     critical_porosity=0.4,
     shear_reduction=1.0,
-    coordination_number=9,
-    cement_coordination_number = 9,
+    friable_coordination_number=9,
+    cement_coordination_number=9,
 ):
     """
     A hybrid sandstone model based on the patchy cement model of Avseth et. al (2016).
 
     :param sand: Material representing the sand of the sandstone.
     :param cement: Material representing the cement of the sandstone.
-    :param porosity: Porosity of the uncemented sandstone.
+    :param porosity: Porosity of the friable sandstone.
     :param contact_cement_porosity: Porosity of the contact cement in the
         hybrid model.
-    :param constant_cement_porosity: The porosity of constant cement
+    :param upper_bound_porosity: The porosity of constant cement
         in the hybrid model.
     :param pressure: Pressure used for friable sand.
     :param lower_bound_pressure: The pressure used for the lower bound
         friable sand.
     :param critical_porosity: The critical porosity of the sandstone.
     :param shear_reduction: Shear reduction factor.
-    :param coordination number: The coordination number of the sand.
+    :param friable_coordination_number: The number of grain-grain contacts in the friable model
+    :param cement_coordination_number: The number of grain-grain contacts in the cemented model - to be kept constant
 
     Avseth, Per & Skjei, Norunn & Mavko, Gary. (2016). Rock-physics modeling of
     stress sensitivity and 4D time shifts in patchy cemented sandstones —
@@ -55,7 +56,7 @@ def patchy_cement(
         porosity,
         critical_porosity,
         pressure,
-        coordination_number,
+        friable_coordination_number,
         shear_reduction,
     )
     lower_bound = friable_sand(
@@ -63,7 +64,7 @@ def patchy_cement(
         porosity,
         critical_porosity,
         lower_bound_pressure,
-        coordination_number,
+        friable_coordination_number,
         shear_reduction,
     )
     upper_bound = constant_cement(

--- a/src/open_petro_elastic/material/sandstone/patchy_cement.py
+++ b/src/open_petro_elastic/material/sandstone/patchy_cement.py
@@ -22,6 +22,7 @@ def patchy_cement(
     critical_porosity=0.4,
     shear_reduction=1.0,
     coordination_number=9,
+    cement_coordination_number = 9,
 ):
     """
     A hybrid sandstone model based on the patchy cement model of Avseth et. al (2016).
@@ -71,7 +72,7 @@ def patchy_cement(
         porosity,
         upper_bound_porosity,
         critical_porosity,
-        coordination_number,
+        cement_coordination_number,
         shear_reduction,
     )
     contact = contact_cement(
@@ -80,7 +81,7 @@ def patchy_cement(
         contact_cement_porosity,
         critical_porosity,
         shear_reduction,
-        coordination_number,
+        cement_coordination_number,
     )
     constant = hashin_shtrikman_walpole(
         dense_packing, contact, 1 - porosity / contact_cement_porosity


### PR DESCRIPTION
The PEM implementation of Patchy Cement model has been compared line-by-line with the RokDoc plugin implementation and the original scripts by Norunn Skjei. Three main differences have been established, one of which was a bug that @eivindjahren has already corrected. The two other differences are documented in the commits of this fork. There are also one change made to ease comparison of results with RokDoc (and possible other implementations), in that more resulting parameters from the calculations are written to csv-file.